### PR TITLE
Supports custom owners having priority to the vendor.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "aws_ami" "search" {
   }
 
   name_regex = "${lookup("${var.amis_os_map_regex}", "${var.os}")}"
-  owners = ["${distinct(concat(compact(var.amis_primary_owners), [lookup(var.amis_os_map_owners, var.os)]))}"]
+  owners = ["${distinct(concat(compact(var.amis_primary_owners), list(lookup(var.amis_os_map_owners, var.os))))}"]
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "aws_ami" "search" {
   }
 
   name_regex = "${lookup("${var.amis_os_map_regex}", "${var.os}")}"
-  owners = ["${lookup("${var.amis_os_map_owners}", "${var.os}")}"]
+  owners = distinct(compact(var.amis_primary_owners), concat(["${lookup("${var.amis_os_map_owners}", "${var.os}")}"]))
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "aws_ami" "search" {
   }
 
   name_regex = "${lookup("${var.amis_os_map_regex}", "${var.os}")}"
-  owners = "${distinct(compact(var.amis_primary_owners), concat(["${lookup("${var.amis_os_map_owners}", "${var.os}")}"]))}"
+  owners = ["${distinct(concat(compact(var.amis_primary_owners), lookup(var.amis_os_map_owners, var.os)))}"]
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "aws_ami" "search" {
   }
 
   name_regex = "${lookup("${var.amis_os_map_regex}", "${var.os}")}"
-  owners = ["${distinct(concat(compact(var.amis_primary_owners), lookup(var.amis_os_map_owners, var.os)))}"]
+  owners = ["${distinct(concat(compact(var.amis_primary_owners), [lookup(var.amis_os_map_owners, var.os)]))}"]
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "aws_ami" "search" {
   }
 
   name_regex = "${lookup("${var.amis_os_map_regex}", "${var.os}")}"
-  owners = distinct(compact(var.amis_primary_owners), concat(["${lookup("${var.amis_os_map_owners}", "${var.os}")}"]))
+  owners = "${distinct(compact(var.amis_primary_owners), concat(["${lookup("${var.amis_os_map_owners}", "${var.os}")}"]))}"
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "aws_ami" "search" {
   }
 
   name_regex = "${lookup("${var.amis_os_map_regex}", "${var.os}")}"
-  owners = ["${lookup("${var.amis_os_map_owners}", "${var.os}")}"]
+  owners = ["${distinct(concat(compact(var.amis_primary_owners), list(lookup(var.amis_os_map_owners, var.os))))}"]
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,11 @@ variable "os" {
    description = "The Os reference to search for"
 }
 
+variable "amis_primary_owners" {
+   description = "The primary AWS owners priors the official and public owner"
+   default     = ["self"]
+}
+
 variable "amis_os_map_regex" {
   description = "Map of regex to search amis"
   type = "map"
@@ -30,7 +35,6 @@ variable "amis_os_map_regex" {
     windows-2008-r2-base = "^Windows_Server-2008-R2_SP1-English-64Bit-Base-.*"
   }
 }
-
 
 variable "amis_os_map_owners" {
   description = "Map of amis owner to filter only official amis"


### PR DESCRIPTION
For some use cases, patched OS or internally "validated" AMIs may be needed.
This PR add "self" account as the default provider, then the vendor is searched. But sometimes, for large companies, another account may own the "valid" AMIs.