### PR TITLE
 Supports use of specific Ami Owner.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
-# Compiled files
-*.tfstate
-*.tfstate.backup
+# Created by .ignore support plugin (hsz.mobi)
+### Terraform template
+#  Local .terraform directories
+**/.terraform/*
 
-# Module directory
-.terraform/
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# .tfvars files
+*.tfvars
+
+.idea/

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "aws_ami" "search" {
   }
 
   name_regex = "${lookup("${var.amis_os_map_regex}", "${var.os}")}"
-  owners = ["${distinct(concat(compact(var.amis_primary_owners), [lookup(var.amis_os_map_owners, var.os)]))}"]
+  owners = ["${distinct(concat(compact(var.amis_primary_owners), list(lookup(var.amis_os_map_owners, var.os))))}"]
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "aws_ami" "search" {
   }
 
   name_regex = "${lookup("${var.amis_os_map_regex}", "${var.os}")}"
-  owners = ["${lookup("${var.amis_os_map_owners}", "${var.os}")}"]
+  owners = distinct(compact(var.amis_primary_owners), concat(["${lookup("${var.amis_os_map_owners}", "${var.os}")}"]))
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "aws_ami" "search" {
   }
 
   name_regex = "${lookup("${var.amis_os_map_regex}", "${var.os}")}"
-  owners = ["${distinct(concat(compact(var.amis_primary_owners), list(lookup(var.amis_os_map_owners, var.os))))}"]
+  owners= ["${length(var.amis_primary_owners) == 0 ? lookup(var.amis_os_map_owners, var.os):var.amis_primary_owners}"]
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "aws_ami" "search" {
   }
 
   name_regex = "${lookup("${var.amis_os_map_regex}", "${var.os}")}"
-  owners = "${distinct(compact(var.amis_primary_owners), concat(["${lookup("${var.amis_os_map_owners}", "${var.os}")}"]))}"
+  owners = ["${distinct(concat(compact(var.amis_primary_owners), lookup(var.amis_os_map_owners, var.os)))}"]
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "aws_ami" "search" {
   }
 
   name_regex = "${lookup("${var.amis_os_map_regex}", "${var.os}")}"
-  owners = ["${distinct(concat(compact(var.amis_primary_owners), lookup(var.amis_os_map_owners, var.os)))}"]
+  owners = ["${distinct(concat(compact(var.amis_primary_owners), [lookup(var.amis_os_map_owners, var.os)]))}"]
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "aws_ami" "search" {
   }
 
   name_regex = "${lookup("${var.amis_os_map_regex}", "${var.os}")}"
-  owners = distinct(compact(var.amis_primary_owners), concat(["${lookup("${var.amis_os_map_owners}", "${var.os}")}"]))
+  owners = "${distinct(compact(var.amis_primary_owners), concat(["${lookup("${var.amis_os_map_owners}", "${var.os}")}"]))}"
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "aws_ami" "search" {
   }
 
   name_regex = "${lookup("${var.amis_os_map_regex}", "${var.os}")}"
-  owners = ["${lookup("${var.amis_os_map_owners}", "${var.os}")}"]
+  owners = ["${distinct(concat(compact(var.amis_primary_owners), list(lookup(var.amis_os_map_owners, var.os))))}"]
 }
 
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "root_device_name" {
   description = "The device name of the root dev"
   value = "${data.aws_ami.search.root_device_name}"
 }
+
+output "owner_id" {
+  description = "The owner id of the selected ami"
+  value = "${data.aws_ami.search.owner_id}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,11 @@ variable "os" {
    description = "The Os reference to search for"
 }
 
+variable "amis_primary_owners" {
+   description = "The primary AWS owners priors the official and public owner"
+   default     = ["self"]
+}
+
 variable "amis_os_map_regex" {
   description = "Map of regex to search amis"
   type = "map"
@@ -30,7 +35,6 @@ variable "amis_os_map_regex" {
     windows-2008-r2-base = "^Windows_Server-2008-R2_SP1-English-64Bit-Base-.*"
   }
 }
-
 
 variable "amis_os_map_owners" {
   description = "Map of amis owner to filter only official amis"

--- a/variables.tf
+++ b/variables.tf
@@ -3,8 +3,8 @@ variable "os" {
 }
 
 variable "amis_primary_owners" {
-   description = "The primary AWS owners priors the official and public owner"
-   default     = ["self"]
+   description = "Force the ami Owner, could be (self) or specific (id)"
+   default     = ""
 }
 
 variable "amis_os_map_regex" {


### PR DESCRIPTION
 Supports use of specific Ami Owner:
Add var.amis_primary_owners = "" (coulf be self of owner id)