### PR TITLE
Take lists as input and ouput a map

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 # get amis data from aws
 data "aws_ami" "search" {
+  count = "${length(var.os)}"
   most_recent = true
 
  filter {
@@ -7,8 +8,7 @@ data "aws_ami" "search" {
     values = ["hvm"]
   }
 
-  name_regex = "${lookup("${var.amis_os_map_regex}", "${var.os}")}"
-  owners= ["${length(var.amis_primary_owners) == 0 ? lookup(var.amis_os_map_owners, var.os):var.amis_primary_owners}"]
+  name_regex = "${lookup("${var.amis_os_map_regex}", "${var.os[count.index]}")}"
+
+  owners= ["${length(var.amis_primary_owners) == 0 ? lookup(var.amis_os_map_owners, var.os[count.index]):var.amis_primary_owners}"]
 }
-
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,4 @@
-output "ami_id" {
-  description = "The AMI id result of the search"
-  value = "${data.aws_ami.search.id}"
-}
-
-output "root_device_name" {
-  description = "The device name of the root dev"
-  value = "${data.aws_ami.search.root_device_name}"
-}
-
-output "owner_id" {
-  description = "The owner id of the selected ami"
-  value = "${data.aws_ami.search.owner_id}"
+output "ami_ids" {
+  description = "The AMI ids result of the search"
+  value = "${zipmap(var.os, data.aws_ami.search.*.id)}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,11 @@
 variable "os" {
-   description = "The Os reference to search for"
+  description = "The Os reference to search for"
+  type        = "list"
 }
 
 variable "amis_primary_owners" {
-   description = "Force the ami Owner, could be (self) or specific (id)"
-   default     = ""
+  description = "Force the ami Owner, could be (self) or specific (id)"
+  default     = ""
 }
 
 variable "amis_os_map_regex" {


### PR DESCRIPTION
Since terraform doesn't have a count for modules, it's hard to use this modules if you want to resolve a lot of AMIs.

This PR will basically change the input to be a list instead and makes it output a map.

So for example for this input: `["ubuntu", "windows-2012-base"]` it would have the following output:

```
{
  ubuntu = ami-028d6461780695a43
  windows-2012-base = ami-0f04f6ba31e5e53d4
}
```