### PR TITLE
Update supported OS list

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.99.1"
+  hashes = [
+    "h1:967WCGUW/vgrjUMBvC+HCie1DVgOXHwUkhm2ng3twJw=",
+    "zh:00b0a61c6d295300f0aa7a79a7d40e9f836164f1fff816d38324c148cd846887",
+    "zh:1ee9d5ccb67378704642db62113ac6c0d56d69408a9c1afb9a8e14b095fc0733",
+    "zh:2035977ed418dcb18290785c1eeb79b7133b39f718c470346e043ac48887ffc7",
+    "zh:67e3ca1bf7061900f81cf958d5c771a2fd6048c2b185bec7b27978349b173a90",
+    "zh:87fadbe5de7347ede72ad879ff8d8d9334103cd9aa4a321bb086bfac91654944",
+    "zh:901d170c457c2bff244a2282d9de595bdb3ebecc33a2034c5ce8aafbcff66db9",
+    "zh:92c07d6cf530679565b87934f9f98604652d787968cce6a3d24c148479b7e34b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a7d4803b4c5ff17f029f8b270c91480442ece27cec7922c38548bcfea2ac2d26",
+    "zh:afda848da7993a07d29018ec25ab6feda652e01d4b22721da570ce4fcc005292",
+    "zh:baaf16c98b81bad070e0908f057a97108ecd6e8c9f754d7a79b18df4c8453279",
+    "zh:c3dd496c5014427599d6b6b1c14c7ebb09a15df78918ae0be935e7bfa83b894c",
+    "zh:e2b84c1d40b3f2c4b1d74bf170b9e932983b61bac0e6dab2e36f5057ddcc997f",
+    "zh:e49c92cb29c53b4573ed4d9c946486e6bcfc1b63f1aee0c79cc7626f3d9add03",
+    "zh:efae8e339c4b13f546e0f96c42eb95bf8347de22e941594849b12688574bf380",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -21,12 +21,16 @@ rhel -> rhel-8
 rhel-7
 rhel-8
 rhel-9
+alma -> alma-9
+alma-8
+alma-9
 debian -> debian-11
 debian-10
 debian-11
 fedora-37
 amazon
 amazon-2_lts
+amazon-2023
 suse-les -> suse-les-12
 suse-les-12
 

--- a/README.md
+++ b/README.md
@@ -10,22 +10,21 @@ Set the 'os' var from the below list:
 
 ``` bash
 # Linux
-ubuntu -> ubuntu-16.04
-ubuntu-14.04
-ubuntu-16.04
+ubuntu -> ubuntu-22.04
+ubuntu-18.04
+ubuntu-20.04
+ubuntu-22.04
 centos -> centos-7
-centos-6
 centos-7
-centos-8
-rhel -> rhel-7
-rhel-6
+centos-9
+rhel -> rhel-8
 rhel-7
 rhel-8
-debian -> debian-9
-debian-8
-debian-9
+rhel-9
+debian -> debian-11
 debian-10
-fedora-27
+debian-11
+fedora-37
 amazon
 amazon-2_lts
 suse-les -> suse-les-12
@@ -33,12 +32,10 @@ suse-les-12
 
 
 # Windows
-windows -> windows-2019-base
+windows -> windows-2022-base
+windows-2022-base
 windows-2019-base
 windows-2016-base
-windows-2012-r2-base
-windows-2012-base
-windows-2008-r2-base
 ```
 
 Examples

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ debian -> debian-11
 debian-10
 debian-11
 fedora-37
-amazon
 amazon-2_lts
 amazon-2023
 suse-les -> suse-les-12

--- a/main.tf
+++ b/main.tf
@@ -7,8 +7,8 @@ data "aws_ami" "search" {
     values = ["hvm"]
   }
 
-  name_regex = lookup("${var.amis_os_map_regex}", "${var.os}")
-  owners     = ["${length(var.amis_primary_owners) == 0 ? lookup(var.amis_os_map_owners, var.os) : var.amis_primary_owners}"]
+  name_regex = lookup(var.amis_os_map_regex, var.os)
+  owners     = [length(var.amis_primary_owners) == 0 ? lookup(var.amis_os_map_owners, var.os) : var.amis_primary_owners]
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -2,13 +2,13 @@
 data "aws_ami" "search" {
   most_recent = true
 
- filter {
+  filter {
     name   = "virtualization-type"
     values = ["hvm"]
   }
 
-  name_regex = "${lookup("${var.amis_os_map_regex}", "${var.os}")}"
-  owners= ["${length(var.amis_primary_owners) == 0 ? lookup(var.amis_os_map_owners, var.os):var.amis_primary_owners}"]
+  name_regex = lookup("${var.amis_os_map_regex}", "${var.os}")
+  owners     = ["${length(var.amis_primary_owners) == 0 ? lookup(var.amis_os_map_owners, var.os) : var.amis_primary_owners}"]
 }
 
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,14 @@
 output "ami_id" {
   description = "The AMI id result of the search"
-  value = "${data.aws_ami.search.id}"
+  value       = data.aws_ami.search.id
 }
 
 output "root_device_name" {
   description = "The device name of the root dev"
-  value = "${data.aws_ami.search.root_device_name}"
+  value       = data.aws_ami.search.root_device_name
 }
 
 output "owner_id" {
   description = "The owner id of the selected ami"
-  value = "${data.aws_ami.search.owner_id}"
+  value       = data.aws_ami.search.owner_id
 }

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+terraform fmt -check main.tf outputs.tf variables.tf
+terraform init -backend=false
+terraform validate

--- a/variables.tf
+++ b/variables.tf
@@ -30,7 +30,6 @@ variable "amis_os_map_regex" {
     "debian-10"         = "^debian-10-.*"
     "debian-11"         = "^debian-11-.*"
     "fedora-37"         = "^Fedora-Cloud-Base-37-.*-gp2.*"
-    amazon              = "^amzn-ami-hvm-.*x86_64-gp2"
     amazon-2_lts        = "^amzn2-ami-hvm-.*x86_64-gp2"
     amazon-2023         = "^al2023-ami-.*x86_64.*"
     suse-les            = "^suse-sles-12-sp\\d-v\\d{8}-hvm-ssd-x86_64"
@@ -64,7 +63,6 @@ variable "amis_os_map_owners" {
     "debian-10"         = "136693071363"
     "debian-11"         = "136693071363"
     "fedora-37"         = "125523088429" #Fedora
-    amazon              = "137112412989" #amazon
     amazon-2_lts        = "137112412989" #amazon
     amazon-2023         = "137112412989" #amazon
     suse-les            = "013907871322" #amazon

--- a/variables.tf
+++ b/variables.tf
@@ -1,81 +1,69 @@
 variable "os" {
-   description = "The Os reference to search for"
+  description = "The Os reference to search for"
 }
 
 variable "amis_primary_owners" {
-   description = "Force the ami Owner, could be (self) or specific (id)"
-   default     = ""
+  description = "Force the ami Owner, could be (self) or specific (id)"
+  default     = ""
 }
 
 variable "amis_os_map_regex" {
   description = "Map of regex to search amis"
-  type = "map"
+  type        = map(string)
 
   default = {
-    ubuntu       = "^ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-.*"
-    ubuntu-14.04 = "^ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-.*"
-    ubuntu-16.04 = "^ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-.*"
-    ubuntu-18.04 = "^ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-.*"
-    ubuntu-18.10 = "^ubuntu/images/hvm-ssd/ubuntu-cosmic-18.10-amd64-server-.*"
-    ubuntu-19.04 = "^ubuntu/images/hvm-ssd/ubuntu-disco-19.04-amd64-server-.*"
-    centos       = "^CentOS.Linux.7.*x86_64.*"
-    centos-6     = "^CentOS.Linux.6.*x86_64.*"
-    centos-7     = "^CentOS.Linux.7.*x86_64.*"
-    centos-8     = "^CentOS.Linux.8.*x86_64.*"
-    rhel         = "^RHEL-7.*x86_64.*"
-    rhel-6       = "^RHEL-6.*x86_64.*"
-    rhel-7       = "^RHEL-7.*x86_64.*"
-    rhel-8       = "^RHEL-8.*x86_64.*"
-    debian       = "^debian-stretch-.*"
-    debian-8     = "^debian-jessie-.*"
-    debian-9     = "^debian-stretch-.*"
-    "debian-10"  = "^debian-10-.*"
-    fedora-27    = "^Fedora-Cloud-Base-27-.*-gp2.*"
-    amazon       = "^amzn-ami-hvm-.*x86_64-gp2"
-    amazon-2_lts = "^amzn2-ami-hvm-.*x86_64-gp2"
-    suse-les     = "^suse-sles-12-sp\\d-v\\d{8}-hvm-ssd-x86_64"
-    suse-les-12  = "^suse-sles-12-sp\\d-v\\d{8}-hvm-ssd-x86_64"
-    windows      = "^Windows_Server-2019-English-Full-Base-.*"
-    windows-2019-base    = "^Windows_Server-2019-English-Full-Base-.*"
-    windows-2016-base    = "^Windows_Server-2016-English-Full-Base-.*"
-    windows-2012-r2-base = "^Windows_Server-2012-R2_RTM-English-64Bit-Base-.*"
-    windows-2012-base    = "^Windows_Server-2012-RTM-English-64Bit-Base-.*"
-    windows-2008-r2-base = "^Windows_Server-2008-R2_SP1-English-64Bit-Base-.*"
+    ubuntu              = "^ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-.*"
+    "ubuntu-18.04"      = "^ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-.*"
+    "ubuntu-20.04"      = "^ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-.*"
+    "ubuntu-22.04"      = "^ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-.*"
+    centos              = "^CentOS.Linux.7.*x86_64.*"
+    "centos-7"          = "^CentOS.Linux.7.*x86_64.*"
+    "centos-9"          = "^CentOS Stream 9.*x86_64.*"
+    rhel                = "^RHEL-8.*x86_64.*"
+    "rhel-7"            = "^RHEL-7.*x86_64.*"
+    "rhel-8"            = "^RHEL-8.*x86_64.*"
+    "rhel-9"            = "^RHEL-9.*x86_64.*"
+    debian              = "^debian-11-.*"
+    "debian-10"         = "^debian-10-.*"
+    "debian-11"         = "^debian-11-.*"
+    "fedora-37"         = "^Fedora-Cloud-Base-37-.*-gp2.*"
+    amazon              = "^amzn-ami-hvm-.*x86_64-gp2"
+    amazon-2_lts        = "^amzn2-ami-hvm-.*x86_64-gp2"
+    suse-les            = "^suse-sles-12-sp\\d-v\\d{8}-hvm-ssd-x86_64"
+    "suse-les-12"       = "^suse-sles-12-sp\\d-v\\d{8}-hvm-ssd-x86_64"
+    windows             = "^Windows_Server-2022-English-Full-Base-.*"
+    "windows-2022-base" = "^Windows_Server-2022-English-Full-Base-.*"
+    "windows-2019-base" = "^Windows_Server-2019-English-Full-Base-.*"
+    "windows-2016-base" = "^Windows_Server-2016-English-Full-Base-.*"
   }
 }
 
 variable "amis_os_map_owners" {
   description = "Map of amis owner to filter only official amis"
-  type = "map"
-   default = {
-      ubuntu       = "099720109477" #CANONICAL
-      ubuntu-14.04 = "099720109477" #CANONICAL
-      ubuntu-16.04 = "099720109477" #CANONICAL
-      ubuntu-18.04 = "099720109477" #CANONICAL
-      ubuntu-18.10 = "099720109477" #CANONICAL
-      ubuntu-19.04 = "099720109477" #CANONICAL
-      rhel         = "309956199498" #Amazon Web Services
-      rhel-6       = "309956199498" #Amazon Web Services
-      rhel-7       = "309956199498" #Amazon Web Services
-      rhel-8       = "309956199498" #Amazon Web Services
-      centos       = "679593333241"
-      centos-6     = "679593333241"
-      centos-7     = "679593333241"
-      centos-8     = "679593333241"
-      debian       = "679593333241"
-      debian-8     = "679593333241"
-      debian-9     = "679593333241"
-      "debian-10"    = "136693071363"
-      fedora-27    = "125523088429" #Fedora
-      amazon       = "137112412989" #amazon
-      amazon-2_lts = "137112412989" #amazon
-      suse-les     = "013907871322" #amazon
-      suse-les-12  = "013907871322" #amazon
-      windows              = "801119661308" #amazon
-      windows-2019-base    = "801119661308" #amazon
-      windows-2016-base    = "801119661308" #amazon
-      windows-2012-r2-base = "801119661308" #amazon
-      windows-2012-base    = "801119661308" #amazon
-      windows-2008-r2-base = "801119661308" #amazon
+  type        = map(string)
+  default = {
+    ubuntu              = "099720109477" #CANONICAL
+    "ubuntu-18.04"      = "099720109477" #CANONICAL
+    "ubuntu-20.04"      = "099720109477" #CANONICAL
+    "ubuntu-22.04"      = "099720109477" #CANONICAL
+    rhel                = "309956199498" #Amazon Web Services
+    "rhel-7"            = "309956199498" #Amazon Web Services
+    "rhel-8"            = "309956199498" #Amazon Web Services
+    "rhel-9"            = "309956199498" #Amazon Web Services
+    centos              = "679593333241"
+    "centos-7"          = "679593333241"
+    "centos-9"          = "679593333241"
+    debian              = "136693071363"
+    "debian-10"         = "136693071363"
+    "debian-11"         = "136693071363"
+    "fedora-37"         = "125523088429" #Fedora
+    amazon              = "137112412989" #amazon
+    amazon-2_lts        = "137112412989" #amazon
+    suse-les            = "013907871322" #amazon
+    "suse-les-12"       = "013907871322" #amazon
+    windows             = "801119661308" #amazon
+    "windows-2022-base" = "801119661308" #amazon
+    "windows-2019-base" = "801119661308" #amazon
+    "windows-2016-base" = "801119661308" #amazon
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,11 @@
 variable "os" {
   description = "The Os reference to search for"
+  type        = string
 }
 
 variable "amis_primary_owners" {
   description = "Force the ami Owner, could be (self) or specific (id)"
+  type        = string
   default     = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,9 @@ variable "amis_os_map_regex" {
     centos              = "^CentOS.Linux.7.*x86_64.*"
     "centos-7"          = "^CentOS.Linux.7.*x86_64.*"
     "centos-9"          = "^CentOS Stream 9.*x86_64.*"
+    alma                = "^almalinux-9.*x86_64.*"
+    "alma-8"            = "^almalinux-8.*x86_64.*"
+    "alma-9"            = "^almalinux-9.*x86_64.*"
     rhel                = "^RHEL-8.*x86_64.*"
     "rhel-7"            = "^RHEL-7.*x86_64.*"
     "rhel-8"            = "^RHEL-8.*x86_64.*"
@@ -29,6 +32,7 @@ variable "amis_os_map_regex" {
     "fedora-37"         = "^Fedora-Cloud-Base-37-.*-gp2.*"
     amazon              = "^amzn-ami-hvm-.*x86_64-gp2"
     amazon-2_lts        = "^amzn2-ami-hvm-.*x86_64-gp2"
+    amazon-2023         = "^al2023-ami-.*x86_64.*"
     suse-les            = "^suse-sles-12-sp\\d-v\\d{8}-hvm-ssd-x86_64"
     "suse-les-12"       = "^suse-sles-12-sp\\d-v\\d{8}-hvm-ssd-x86_64"
     windows             = "^Windows_Server-2022-English-Full-Base-.*"
@@ -53,12 +57,16 @@ variable "amis_os_map_owners" {
     centos              = "679593333241"
     "centos-7"          = "679593333241"
     "centos-9"          = "679593333241"
+    alma                = "879944229104"
+    "alma-8"            = "879944229104"
+    "alma-9"            = "879944229104"
     debian              = "136693071363"
     "debian-10"         = "136693071363"
     "debian-11"         = "136693071363"
     "fedora-37"         = "125523088429" #Fedora
     amazon              = "137112412989" #amazon
     amazon-2_lts        = "137112412989" #amazon
+    amazon-2023         = "137112412989" #amazon
     suse-les            = "013907871322" #amazon
     "suse-les-12"       = "013907871322" #amazon
     windows             = "801119661308" #amazon


### PR DESCRIPTION
## Summary
- switch Ubuntu default to 22.04 and remove old releases
- drop deprecated CentOS, Debian and Windows versions
- add latest releases like RHEL 9 and Windows Server 2022
- update README to show new operating system list
- fix HCL syntax so module works with Terraform 1.x
- add terraform lock file from running `terraform init`

## Testing
- `terraform fmt -check main.tf outputs.tf variables.tf`
- `terraform init -backend=false`
- `terraform validate`
